### PR TITLE
Fix iptables setup script

### DIFF
--- a/setup_tools.sh
+++ b/setup_tools.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-printf "Setup Iptables...\n"
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root" >&2
+    exit 1
+fi
+
+printf "Setup iptables...\n"
 update-alternatives --set iptables /usr/sbin/iptables-legacy
-iptables -I INPUT -s 192.168.3.0/24 -j ACCEPT && \
-iptables -A FORWARD -o eth0 -i wlan0 -s 192.168.2.0/24 -m conntrack --ctstate NEW -j ACCEPT && \
-iptables -A FORWARD -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT && \
-iptables -t nat -F POSTROUTING && \
+iptables -I INPUT -s 192.168.3.0/24 -j ACCEPT
+iptables -A FORWARD -o eth0 -i wlan0 -s 192.168.2.0/24 -m conntrack --ctstate NEW -j ACCEPT
+iptables -A FORWARD -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+iptables -t nat -F POSTROUTING
 iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
 printf "Done\n"


### PR DESCRIPTION
## Summary
- enforce root usage in setup script
- exit on first failure to avoid partial configuration

## Testing
- `bash -n setup_tools.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f4615457483268d837a207dfc0652